### PR TITLE
SUBMARINE-195. Fix the incorrect project name in merge_submarine_pr.py

### DIFF
--- a/dev-support/cicd/merge_submarine_pr.py
+++ b/dev-support/cicd/merge_submarine_pr.py
@@ -243,7 +243,7 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     print ("summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n" % (
         cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id))
 
-    versions = asf_jira.project_versions("HADOOP-SUBMARINE")
+    versions = asf_jira.project_versions("SUBMARINE")
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
     versions = filter(lambda x: x.raw['released'] is False, versions)
     # Consider only x.y.z versions


### PR DESCRIPTION
### What is this PR for?
When it merges the PR and the committer chose to close Jira, it fails with something like project "HADOOP-SUBMARINE" not be found. Tested that change it to "SUBMARINE" will work. 

### What type of PR is it?
Bug Fix
### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-195

### How should this be tested?
use the cicd image to do the PR merge. And also choose yes to update the associated JIRA.
It will work with this fix.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
