### PR TITLE
[SUBMARINE-199] Add instructions for working with CICD via python script

### DIFF
--- a/dev-support/cicd/README.md
+++ b/dev-support/cicd/README.md
@@ -44,7 +44,7 @@ Enter Your Apache JIRA User name:
 
 ## Manual mode
 
-First, You need install `python 2.7.13` and `pip insalll jira`
+First, You need install `python 2.7.13` and `pip insall jira`
 
 ### The Procedure of Merging PR
 

--- a/dev-support/cicd/README.md
+++ b/dev-support/cicd/README.md
@@ -11,16 +11,23 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-# Introduction
+# CICD Introduction
+
+> Please note that cicd is a tool provided to submarine committers for PR merging and release. Only submarine committers have permission to execute.
+
 This cicd directory contains several scripts to ease code and release management.
 To use them more easily, we provide a Docker image to help committer to handle tasks like committing code and release build.
+
+## Docker mode
 
 ```
 cd <path-to-submarine-home>/dev-support/cicd
 docker build -t submarine-cicd .
 docker run -it --rm submarine-cicd
 ```
+
 Or
+
 ```
 ./build_and_start_cicd_image.sh
 ```
@@ -34,3 +41,18 @@ Enter Menu ID:1
 ==== Merge PR Begin ====
 Enter Your Apache JIRA User name:
 ```
+
+## Manual mode
+
+### The Procedure of Merging PR
+
+1. mkdir ${work_dir} & cd ${work_dir}
+2. git clone https://git-wip-us.apache.org/repos/asf/hadoop-submarine
+3. cd hadoop-submarine
+4. git remote rename origin apache
+5. git remote add apache-github https://github.com/apache/hadoop-submarine.git
+6. optional: git config --local --add user.name {name} 
+7. optional: git config --local --add user.email {username}@apache.org
+8. optional: echo -e "JIRA_USERNAME={jira_username}\nJIRA_PASSWORD={jira_password}" >> ~/.bashrc
+9. optional: source ~/.bashrc
+10. dev-support/cicd/merge_submarine_pr.py

--- a/dev-support/cicd/README.md
+++ b/dev-support/cicd/README.md
@@ -44,15 +44,19 @@ Enter Your Apache JIRA User name:
 
 ## Manual mode
 
+First, You need install `python 2.7.13` and `pip insalll jira`
+
 ### The Procedure of Merging PR
 
-1. mkdir ${work_dir} & cd ${work_dir}
-2. git clone https://git-wip-us.apache.org/repos/asf/hadoop-submarine
-3. cd hadoop-submarine
-4. git remote rename origin apache
-5. git remote add apache-github https://github.com/apache/hadoop-submarine.git
-6. optional: git config --local --add user.name {name} 
-7. optional: git config --local --add user.email {username}@apache.org
-8. optional: echo -e "JIRA_USERNAME={jira_username}\nJIRA_PASSWORD={jira_password}" >> ~/.bashrc
-9. optional: source ~/.bashrc
-10. dev-support/cicd/merge_submarine_pr.py
+1. mkdir ${work_dir}
+2. cd ${work_dir}
+3. git clone https://gitbox.apache.org/repos/asf/hadoop-submarine.git
+4. cd hadoop-submarine
+5. git remote rename origin apache
+6. git remote add apache-github https://github.com/apache/hadoop-submarine.git
+7. optional: git config --local --add user.name {name} 
+8. optional: git config --local --add user.email {username}@apache.org
+9. optional: echo -e "JIRA_USERNAME={jira_username}\nJIRA_PASSWORD={jira_password}" >> ~/.bashrc
+10. optional: source ~/.bashrc
+11. dev-support/cicd/merge_submarine_pr.py
+


### PR DESCRIPTION
### What is this PR for?
Currently submarine supports CICD through docker.
In the absence of a docker environment, merge PR operations can also be performed by means of python scripts.
Adding this documentation will also help users understand the submarine merge PR execution process.


### What type of PR is it?
[Documentation]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-199

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/589737584)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
