### PR TITLE
[SUBMARINE-177] Replace mysql-driver in the submarine-service with de…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
     <nimbus-jose-jwt.version>4.41.1</nimbus-jose-jwt.version>
     <commons-io.version>2.4</commons-io.version>
     <mybatis-generator.version>1.3.7</mybatis-generator.version>
+    <derby.version>10.4.2.0</derby.version>
   </properties>
 
   <modules>

--- a/submarine-workbench/submarine-server/pom.xml
+++ b/submarine-workbench/submarine-server/pom.xml
@@ -137,6 +137,13 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>${mysql-connector-java.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>${derby.version}</version>
     </dependency>
 
     <!-- Test libraries -->


### PR DESCRIPTION
### What is this PR for?
Set the scope of the mysql dependent package to provided. Add Derby's driver as an alternative.

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* [SUBMARINE-177](https://issues.apache.org/jira/browse/SUBMARINE-177)

### How should this be tested?
* [CI Pass](https://travis-ci.org/LinhaoZhu/hadoop-submarine/builds/589751612)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
