### PR TITLE
SUBMARINE-207. Exclude mysql jdbc jar from the path of workbench/lib.

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+export DEFAULT_MYSQL_VERSION=5.1.39
+
 if [[ -L ${BASH_SOURCE-$0} ]]; then
   FWDIR=$(dirname $(readlink "${BASH_SOURCE-$0}"))
 else
@@ -62,6 +64,18 @@ function add_jar_in_dir(){
   if [[ -d "${1}" ]]; then
     WORKBENCH_CLASSPATH="${1}/*:${WORKBENCH_CLASSPATH}"
   fi
+}
+
+function download_mysql_jdbc_jar(){
+  if [[ -z "${MYSQL_JAR_URL}" ]]; then
+    if [[ -z "${MYSQL_VERSION}" ]]; then
+      MYSQL_VERSION="${DEFAULT_MYSQL_VERSION}"
+    fi
+    MYSQL_JAR_URL="https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar"
+  fi
+  echo "Downloading mysql jdbc jar from ${MYSQL_JAR_URL}."
+  wget ${MYSQL_JAR_URL} -P "${BIN}/../workbench/lib"
+  echo "Mysql jdbc jar is downloaded and put in the path of workbench/lib."
 }
 
 JAVA_OPTS+=" ${WORKBENCH_JAVA_OPTS} -Dfile.encoding=UTF-8 ${WORKBENCH_MEM}"

--- a/conf/log4j.properties.template
+++ b/conf/log4j.properties.template
@@ -16,7 +16,7 @@
 
 # Define some default values that can be overridden by system properties
 submarine.log.threshold=ALL
-submarine.root.logger=INFO, DRFA, console
+submarine.root.logger=INFO,DRFA,console
 submarine.log.dir=/tmp
 submarine.log.file=submarine.log
 

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -97,7 +97,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>workbench/workbench-web.war</value>
+    <value>../workbench/workbench-web.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/conf/submarine-site.xml.template
+++ b/conf/submarine-site.xml.template
@@ -97,7 +97,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>workbench/workbench-web.war</value>
+    <value>../workbench/workbench-web.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/docs/workbench/README.md
+++ b/docs/workbench/README.md
@@ -24,6 +24,13 @@ submit/manage jobs, manage models, create model training workflows, access datas
 cd submarine
 ./bin/workbench-daemon.sh [start|stop|restart]
 ```
+To start workbench server, you need to download mysql jdbc jar and put it in the
+path of workbench/lib for the first time. Or you can add parameter, getMysqlJar,
+to get mysql jar automatically.
+```$xslt
+cd submarine
+./bin/workbench-daemon.sh start getMysqlJar
+```
 
 ## submarine-env.sh
 
@@ -34,6 +41,8 @@ cd submarine
 | JAVA_HOME           | Set your java home path, default is `java`.                  |
 | WORKBENCH_JAVA_OPTS | Set the JAVA OPTS parameter when the Workbench process starts. If you need to debug the Workbench process, you can set it to `-agentlib:jdwp=transport=dt_socket, server=y,suspend=n,address=5005` |
 | WORKBENCH_MEM       | Set the java memory parameter when the Workbench process starts. |
+| MYSQL_JAR_URL       | The customized URL to download mysql jdbc jar.               |
+| MYSQL_VERSION       | The version of mysql jdbc jar would be downloaded. The default value is 5.1.39. It's used to generate the default value of MYSQL_JDBC_URL|
 
 ## submarine-site.xml
 

--- a/submarine-workbench/workbench-server/pom.xml
+++ b/submarine-workbench/workbench-server/pom.xml
@@ -210,11 +210,25 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy-dependencies</id>
+            <id>copy-dependencies-runtime</id>
             <phase>package</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-dependencies-system</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>system</includeScope>
+              <excludeTransitive>true</excludeTransitive>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
### What is this PR for?
Althogh mysql dependency is set to provided in maven, mysql jar is still added in the path of workbench/lib.
Our package should not include mysql jdbc jar, but provide ways to help customers get mysql jar by themselves easily.  

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-207

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/591077386

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
