### PR TITLE
[SUBMARINE-104]. YARN application type should set SUBMARINE

### DIFF
--- a/submarine-core/src/main/java/org/apache/submarine/common/conf/SubmarineConfiguration.java
+++ b/submarine-core/src/main/java/org/apache/submarine/common/conf/SubmarineConfiguration.java
@@ -34,6 +34,8 @@ public class SubmarineConfiguration extends Configuration {
   // Default 2GB
   public static final long DEFAULT_MAX_ALLOWED_REMOTE_URI_SIZE_MB = 2048;
 
+  public static final String SUBMARINE_RUNTIME_APP_TYPE = "SUBMARINE";
+
   public SubmarineConfiguration() {
     this(new Configuration(false), true);
   }

--- a/submarine-runtime/tony-runtime/src/main/java/org/apache/submarine/runtimes/tony/TonyUtils.java
+++ b/submarine-runtime/tony-runtime/src/main/java/org/apache/submarine/runtimes/tony/TonyUtils.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.submarine.common.conf.SubmarineConfiguration.SUBMARINE_RUNTIME_APP_TYPE;
+
 /**
  * Utilities for Tony Runtime.
  */
@@ -106,6 +108,7 @@ public final class TonyUtils {
     tonyConf.setStrings(TonyConfigurationKeys.CONTAINER_LAUNCH_ENV,
         envs.stream().map(env -> env.replaceAll("DOCKER_", ""))
             .toArray(String[]::new));
+    tonyConf.setStrings(TonyConfigurationKeys.APPLICATION_TYPE, SUBMARINE_RUNTIME_APP_TYPE);
 
     // Set up running command
     if (parameters.getWorkerLaunchCmd() != null) {

--- a/submarine-runtime/tony-runtime/src/test/java/TestTonyUtils.java
+++ b/submarine-runtime/tony-runtime/src/test/java/TestTonyUtils.java
@@ -121,5 +121,6 @@ public class TestTonyUtils {
         Constants.VCORES)));
     Assert.assertEquals(tensorFlowParams.getPSLaunchCmd(),
         tonyConf.get(TonyConfigurationKeys.getExecuteCommandKey("ps")));
+    Assert.assertEquals("SUBMARINE", tonyConf.get(TonyConfigurationKeys.APPLICATION_TYPE));
   }
 }


### PR DESCRIPTION
### What is this PR for?
No matter which runtime we use, we should set the same application type.
Currently,  the application type for Tony run time is "TONY", we should set the  application type to
"SUBMARINE" instead.
### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-104

### Screenshots (if appropriate)
<img width="1131" alt="SUBMARINE-104" src="https://user-images.githubusercontent.com/8197966/65847473-45e72b00-e374-11e9-9732-695c9d954a44.png">

### How should this be tested?
https://travis-ci.org/luzhonghao/hadoop-submarine/builds/591292126

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
