### PR TITLE
SUBMARINE-218. Update hadoop-3.2 profile to use hadoop 3.2.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
         <jackson-annotations.version>2.9.5</jackson-annotations.version>
         <guice.version>4.0</guice.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <guava.version>27.0-jre</guava.version>
         <profile-id>hadoop-3.2</profile-id>
       </properties>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <profile>
       <id>hadoop-3.2</id>
       <properties>
-        <hadoop.version>3.2.0</hadoop.version>
+        <hadoop.version>3.2.1</hadoop.version>
         <jaxb-api.version>2.2.11</jaxb-api.version>
         <commons-compress.version>1.18</commons-compress.version>
         <guice-servlet.version>4.0</guice-servlet.version>

--- a/submarine-runtime/tony-runtime/pom.xml
+++ b/submarine-runtime/tony-runtime/pom.xml
@@ -94,6 +94,10 @@
           <groupId>com.linkedin.azkaban</groupId>
           <artifactId>azkaban-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
Update hadoop-3.2 profile to use Apache Hadoop 3.2.1 release

Hadoop 3.2.1 updated guava version to 27.0-jre, which is not compatible with prior version, so I had to update guava version used too. httpcomponents was updated which differs from the one used by Tony, so exclude httpcomponents from Tony and use the version (newer in Hadoop 3.2) in Hadoop.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. [SUBMARINE-23]

### How should this be tested?
[Travis CI](https://travis-ci.org/jojochuang/hadoop-submarine/builds/594904607)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
