### PR TITLE
SUBMARINE-219. run_submarine_mnist_tony.sh run error in mini-submarine

### DIFF
--- a/dev-support/mini-submarine/conf/submarine.xml
+++ b/dev-support/mini-submarine/conf/submarine.xml
@@ -19,9 +19,9 @@
 <configuration>
   <property>
     <name>submarine.runtime.class</name>
-    <value>org.apache.hadoop.yarn.submarine.runtimes.tony.TonyRuntimeFactory</value>
+    <value>org.apache.submarine.runtimes.tony.TonyRuntimeFactory</value>
     <!--
-    <value>org.apache.hadoop.yarn.submarine.runtimes.yarnservice.YarnServiceRuntimeFactory</value>
+    <value>org.apache.submarine.runtimes.yarnservice.YarnServiceRuntimeFactory</value>
     -->
   </property>
 </configuration>

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
@@ -47,10 +47,10 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi 
 
-SUBMARINE_VERSION=${SUBMARINE_VER}-hadoop-3.1
-SUBMARINE_HOME=/opt/hadoop-submarine-dist-${SUBMARINE_VERSION}
-CLASSPATH=$(hadoop classpath --glob):${SUBMARINE_HOME}/hadoop-submarine-core-${SUBMARINE_VER}.jar:${SUBMARINE_HOME}/hadoop-submarine-tony-runtime-${SUBMARINE_VER}.jar:${SUBMARINE_HOME}/tony-cli-0.3.18-all.jar \
-${JAVA_CMD} org.apache.hadoop.yarn.submarine.client.cli.Cli job run --name tf-job-001 \
+SUBMARINE_VERSION=${SUBMARINE_VER}-hadoop-2.9
+SUBMARINE_HOME=/opt/submarine-dist-${SUBMARINE_VERSION}
+CLASSPATH=$(hadoop classpath --glob):${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar \
+${JAVA_CMD} org.apache.submarine.client.cli.Cli job run --name tf-job-001 \
  --framework tensorflow \
  --verbose \
  --input_path "" \
@@ -61,4 +61,5 @@ ${JAVA_CMD} org.apache.hadoop.yarn.submarine.client.cli.Cli job run --name tf-jo
  --worker_launch_cmd "${WORKER_CMD}" \
  --ps_launch_cmd "myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode" \
  --insecure \
- --conf tony.containers.resources=/home/yarn/submarine/myvenv.zip#archive,/home/yarn/submarine/mnist_distributed.py,${SUBMARINE_HOME}/tony-cli-0.3.18-all.jar
+ --conf tony.containers.resources=/home/yarn/submarine/myvenv.zip#archive,/home/yarn/submarine/mnist_distributed.py,\
+${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar


### PR DESCRIPTION
### What is this PR for?
1. after SUBMARINE-209 merged, we use submarine-0.3.0-SNAPSHOT in mini-submarine, we should update the classpath in run_submarine_mnist_tony.sh

2. we need to update submarine.runtime.class default value org.apache.hadoop.yarn.submarine.runtimes.tony.TonyRuntimeFactory  to org.apache.submarine.runtimes.tony.TonyRuntimeFactory

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-219

### How should this be tested?
https://travis-ci.org/pingsutw/hadoop-submarine/builds/594971628

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
