### PR TITLE
SUBMARINE-222. Use virtual Python env in CICD image

### DIFF
--- a/dev-support/cicd/Dockerfile
+++ b/dev-support/cicd/Dockerfile
@@ -16,8 +16,16 @@
 FROM ubuntu:16.04
 RUN \
   apt-get update && \
-  apt-get install -y vim python git python-pip && \
-  pip install jira
+  apt-get install -y wget vim git python-pip zlib1g-dev libssl-dev && \
+  wget https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz && \
+  tar xzf Python-2.7.13.tgz && cd Python-2.7.13 && ./configure --with-zlib && make install && make altinstall && \
+  cd /root && wget https://files.pythonhosted.org/packages/33/bc/fa0b5347139cd9564f0d44ebd2b147ac97c36b2403943dbee8a25fd74012/virtualenv-16.0.0.tar.gz && \
+  tar xf virtualenv-16.0.0.tar.gz && \
+  python virtualenv-16.0.0/virtualenv.py venv2.7 && \
+  . venv2.7/bin/activate && \
+  pip install jira && \
+  deactivate
+
 RUN \
   git clone https://gitbox.apache.org/repos/asf/hadoop-submarine.git && \
   cd hadoop-submarine && \
@@ -26,5 +34,6 @@ RUN \
 ADD \
   entry.sh /entry.sh
 ENV \
-  SUBMARINE_HOME=/hadoop-submarine
+  SUBMARINE_HOME=/hadoop-submarine \
+  PYTHON_VENV_PATH=/root
 CMD /entry.sh

--- a/dev-support/cicd/entry.sh
+++ b/dev-support/cicd/entry.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set -e
+# activate python 2.7.13 environment
+. ${PYTHON_VENV_PATH}/venv2.7/bin/activate
 
 function start_menu(){
   printf "Menu:\n"
@@ -75,3 +77,4 @@ function merge_pr(){
 }
 
 start_menu
+deactivate


### PR DESCRIPTION
### What is this PR for?
When using the current CICD image, there is a possibility that the merge PR script will fail due to Python environment issue. I propose to use python virtual env to solve this.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-222

### How should this be tested?
re-build the cicd image and use it to merge PR
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
