### PR TITLE
SUBMARINE-229. Submarine-cicd failed due to the encoding error of github PR body

### DIFF
--- a/dev-support/cicd/README.md
+++ b/dev-support/cicd/README.md
@@ -21,25 +21,31 @@ To use them more easily, we provide a Docker image to help committer to handle t
 ## Docker mode
 
 ```
-cd <path-to-submarine-home>/dev-support/cicd
-docker build -t submarine-cicd .
-docker run -it --rm submarine-cicd
+./build_and_start_cicd_image.sh
 ```
 
 Or
 
 ```
-./build_and_start_cicd_image.sh
+cd <path-to-submarine-home>/dev-support/cicd
+docker build -t submarine-cicd .
+docker run -it --rm submarine-cicd
 ```
+
+Jira username, password, apache id and apache username are required in the docker container. You can
+add them to the docker startup command.
 
 And you'll see output like below and then you can decide what to accomplish.
 ```
-$ docker run -it --rm submarine-cicd
+$ docker run -it -e JIRA_USERNAME='jira username' -e JIRA_PASSWORD='jira password' \
+ -e APACHE_ID='apache id' -e APACHE_NAME="apache name" --rm submarine-cicd 
 Menu:
 	1. Merge PR
 Enter Menu ID:1
 ==== Merge PR Begin ====
-Enter Your Apache JIRA User name:
+Got JIRA name: username
+
+Enter Your Apache committer ID:
 ```
 
 ## Manual mode

--- a/dev-support/cicd/merge_submarine_pr.py
+++ b/dev-support/cicd/merge_submarine_pr.py
@@ -134,7 +134,10 @@ def merge_pr(pr_num, target_ref):
     if body is not None:
         # We remove @ symbols from the body to avoid triggering e-mails
         # to people every time someone creates a public fork of Submarine.
-        merge_message_flags += ["-m", body.replace("@", "")]
+        if isinstance(body, unicode):
+            merge_message_flags += ["-m", body.encode("utf-8").replace("@", "")]
+        else:
+            merge_message_flags += ["-m", body.replace("@", "")]
 
     authors = "\n".join(["Author: %s" % a for a in distinct_authors])
 


### PR DESCRIPTION
### What is this PR for?
Sometimes, submarine-cicd failed to merge pr.
The root cause is that the encode of PR body is UTF-8, which would cause python str encoding error.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-229

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/596113339

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
