### PR TITLE
SUBMARINE-234. Add submarine-data.sql to the doc for database.

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -79,6 +79,12 @@ If you need to store Chinese character data in mysql, you need to execute the fo
 ## Create Submarine Database
 
 ### Create development database
+Copy the files, submarine.sql and submarine-data.sql to the mysql docker.
+
+```
+docker cp ${SUBMARINE_HOME}/docs/database/submarine.sql ${DOCKER_ID}:/
+docker cp ${SUBMARINE_HOME}/docs/database/submarine-data.sql ${DOCKER_ID}:/
+```
 
 Development database for development environment.
 
@@ -89,7 +95,8 @@ mysql> CREATE USER 'submarine'@'%' IDENTIFIED BY 'password';
 mysql> GRANT ALL PRIVILEGES ON * . * TO 'submarine'@'%';
 mysql> CREATE DATABASE submarineDB CHARACTER SET utf8 COLLATE utf8_general_ci;
 mysql> use submarineDB;
-mysql> source ./docs/database/submarine.sql;
+mysql> source /submarine.sql;
+mysql> source /submarine-data.sql;
 mysql> quit
 ```
 
@@ -107,7 +114,7 @@ mysql> CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';
 mysql> GRANT ALL PRIVILEGES ON * . * TO 'submarine_test'@'%';
 mysql> CREATE DATABASE `submarineDB_test` CHARACTER SET utf8 COLLATE utf8_general_ci;
 mysql> use `submarineDB_test`;
-mysql> source ./docs/database/submarine.sql;
+mysql> source /submarine.sql;
 mysql> quit
 ```
 


### PR DESCRIPTION
### What is this PR for?
To setup a workbench development environment, the file of submarine-data.sql needs to be executed. But the document doesn't mention it.

### What type of PR is it?
Documentation

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-234

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/596887093

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
