### PR TITLE
SUBMARINE-231. Introducing zeppelin via submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = submodules/tony
 	url = https://github.com/hadoopsubmarine/linkedin-tony.git
 	branch = submarine
+[submodule "submodules/zeppelin"]
+	path = submodules/zeppelin
+	url = https://github.com/hadoopsubmarine/zeppelin.git
+	branch = submarine

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ env:
   global:
     # submarine core does not required by workbench-server integration tests
     # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-runtime/yarnservice-runtime` in EXCLUDE_SUBMARINE_CORE
-    - EXCLUDE_SUBMARINE_CORE="\"!submarine-all,!submarine-core,!submarine-dist,!submarine-runtime/tony-runtime,!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli\""
+    - EXCLUDE_SUBMARINE_CORE="!submarine-all,!submarine-core,!submarine-dist,!submarine-runtime/tony-runtime"
+    - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server"
+    - EXCLUDE_SUBMODULE_TONY="!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli"
+    - EXCLUDE_SUBMODULE_ZEPPELIN="!submodules/zeppelin,!submodules/zeppelin/zeppelin-interpreter-parent,!submodules/zeppelin/zeppelin-interpreter,!submodules/zeppelin/zeppelin-interpreter-api,!submodules/zeppelin/python"
 
 before_install:
   - sudo service mysql restart
@@ -51,35 +54,35 @@ before_install:
 
 matrix:
   include:
-    # Test License compliance using RAT tool
+    # Test License compliance using RAT tool, No need to check submodules/zeppelin
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Check RAT" PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
+      env: NAME="Check RAT" PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" MODULES="-pl \"!submodules/zeppelin\"" TEST_PROJECTS=""
 
     # Build hadoop-2.7
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_ZEPPELIN},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-2.9(default)
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_ZEPPELIN},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.1
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_ZEPPELIN},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.2
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_ZEPPELIN},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build workbench-web
     - language: node_js
@@ -98,19 +101,19 @@ matrix:
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test workbench-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE_CORE}" TEST_MODULES="-pl submarine-workbench/workbench-server" TEST_PROJECTS=""
+      env: NAME="Test workbench-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_SUBMARINE_CORE},${EXCLUDE_SUBMODULE_TONY},${EXCLUDE_SUBMODULE_ZEPPELIN}\"" TEST_MODULES="-pl submarine-workbench/workbench-server" TEST_PROJECTS=""
 
     # Test workbench-web
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE_CORE}" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
+      env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_SUBMARINE_CORE},${EXCLUDE_SUBMODULE_TONY},${EXCLUDE_SUBMODULE_ZEPPELIN}\"" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
 
     # Test submarine distribution
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="" TEST_MODULES="" TEST_PROJECTS=""
+      env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="" TEST_MODULES="-pl \"${EXCLUDE_SUBMODULE_ZEPPELIN}\"" TEST_PROJECTS="" TEST_PROJECTS=""
 
     # Test submarine-sdk
     - language: python
@@ -121,7 +124,7 @@ matrix:
         - pip install -r ./submarine-sdk/pysubmarine/travis/lint-requirements.txt
       script:
         - ./submarine-sdk/pysubmarine/travis/lint.sh
-        - pytest --cov=submarine -vs
+        - pytest --cov=submarine --ignore=submodules/zeppelin -vs
 
 
 install:

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
 
   <modules>
     <module>submodules/tony</module>
+    <module>submodules/zeppelin</module>
     <module>submarine-core</module>
     <module>submarine-all</module>
     <module>submarine-workbench</module>
@@ -413,6 +414,7 @@
             <exclude>**/*.xsd</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.conf</exclude>
+            <exclude>**/*.iml</exclude>
             <exclude>**/src/main/java/com/linkedin/tony/events/*</exclude>
             <exclude>**/src/main/resources/META-INF/services/org.apache.hadoop.security.SecurityInfo</exclude>
             <exclude>**/src/test/resources/typicalHistFolder/job1/application123-1-1-user1-SUCCEEDED.jhist</exclude>


### PR DESCRIPTION
### What is this PR for?
1. First, fork Apache Zeppelin's code repository in the `hadoopsubmarine` account, which ensures that `hadoopsubmarine/zeppelin` can always follow apache/zeppelin code updates.
2. Create a submarine branch in `hadoopsubmarine/zeppelin` and customize the development on this branch.
3. The `hadoopsubmarine/zeppelin` repository is contained via submodule in the apache/submarine repository.
4. In the `/submarine/submarine-interpreter` in the `apache/submarine` repository, we import the JAR package of our customized zeppelin interpreter in submodule for use.

[Sumarine interpreter Design doc](https://docs.google.com/document/d/1LJc5hRTWfIs6K5f7vMgGC_FUizeQf-qqiWICqO8SoR8/edit#)


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-231

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/596891798)

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/3677382/66695830-a1ac9f00-ecf8-11e9-89db-353a0a7900bb.png)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
