### PR TITLE
[SUBMARINE-237] Fixed workbench-daemon.sh returns wrong status

### DIFF
--- a/bin/workbench-daemon.sh
+++ b/bin/workbench-daemon.sh
@@ -148,15 +148,15 @@ function find_workbench_process() {
   pid=`found_workbench_server_pid`
 
   if [[ -z "$pid" ]]; then
+    echo "${WORKBENCH_NAME} is not running"
+    return 1
+  else
     if ! kill -0 ${pid} > /dev/null 2>&1; then
       echo "${WORKBENCH_NAME} running but process is dead"
       return 1
     else
       echo "${WORKBENCH_NAME} is running"
     fi
-  else
-    echo "${WORKBENCH_NAME} is not running"
-    return 1
   fi
 }
 


### PR DESCRIPTION
### What is this PR for?
We start workbench server successfully. However, when  run "workbench-daemon.sh status"  , it returns message "Submarine Workbench is not running" 

### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-237

### How should this be tested?
manual test 
* start workbench server
* run “workbench-daemon.sh  status ” command and see if the return message is correct

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
