### PR TITLE
[SUBMARINE-238] Fix failed to start submarine server

### DIFF
--- a/bin/workbench-daemon.sh
+++ b/bin/workbench-daemon.sh
@@ -31,6 +31,8 @@ GET_MYSQL_JAR=false
 
 . "${BIN}/common.sh"
 
+cd ${BIN}/>/dev/null
+
 WORKBENCH_NAME="Submarine Workbench"
 WORKBENCH_LOGFILE="${SUBMARINE_LOG_DIR}/workbench.log"
 WORKBENCH_MAIN=org.apache.submarine.server.WorkbenchServer


### PR DESCRIPTION
### What is this PR for?
We followed the steps from document https://github.com/apache/hadoop-submarine/tree/master/dev-support/mini-submarine and run "workbench-daemon.sh start getMysqlJar"  at root's home , however, the workbench log complains  the "Files not exist exception" .
It should be fixed.



### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-238

### How should this be tested?
manual test

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
