### PR TITLE
SUBMARINE-235. Submarine Python Interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,11 @@ services:
 env:
   global:
     # submarine core does not required by workbench-server integration tests
-    # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-runtime/yarnservice-runtime` in EXCLUDE_SUBMARINE_CORE
-    - EXCLUDE_SUBMARINE_CORE="\"!submarine-all,!submarine-client,!submarine-commons,!submarine-commons/commons-runtime,!submarine-dist,!submarine-server/server-submitter/submitter-yarn,!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli\""
+    # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-runtime/yarnservice-runtime` in EXCLUDE_SUBMARINE
+    - EXCLUDE_SUBMARINE="!submarine-all,!submarine-client,!submarine-commons,!submarine-commons/commons-runtime,!submarine-dist,!submarine-server/server-submitter/submitter-yarn"
+    - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server"
+    - EXCLUDE_INTERPRETER="!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter"
+    - EXCLUDE_SUBMODULE_TONY="!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli"
 
 before_install:
   - sudo service mysql restart
@@ -48,6 +51,7 @@ before_install:
   - mysql -e "CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';"
   - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'submarine_test'@'%';"
   - mysql -e "use submarineDB_test; source ./docs/database/submarine.sql; show tables;"
+  - ./dev-support/travis/install_external_dependencies.sh
 
 matrix:
   include:
@@ -61,25 +65,25 @@ matrix:
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-2.9(default)
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.1
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.2
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist\"" TEST_PROJECTS=""
+      env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat -am" MODULES="-pl \"${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build workbench-web
     - language: node_js
@@ -98,19 +102,19 @@ matrix:
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test workbench-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE_CORE}" TEST_MODULES="-pl submarine-workbench/workbench-server" TEST_PROJECTS=""
+      env: NAME="Test workbench-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-workbench/workbench-server" TEST_PROJECTS=""
 
     # Test workbench-web
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE_CORE}" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
+      env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
 
-    # Test submarine distribution
+    # Test interpreter
     - language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="" TEST_MODULES="" TEST_PROJECTS=""
+      env: NAME="Test interpreter" PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_TONY}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
 
     # Test submarine-sdk
     - language: python
@@ -123,6 +127,11 @@ matrix:
         - ./submarine-sdk/pysubmarine/travis/lint.sh
         - pytest --cov=submarine -vs
 
+    # Test submarine distribution
+    - language: java
+      jdk: "openjdk8"
+      dist: xenial
+      env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="" TEST_MODULES="" TEST_PROJECTS=""
 
 install:
   - mvn --version

--- a/dev-support/travis/install_external_dependencies.sh
+++ b/dev-support/travis/install_external_dependencies.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script for installing R / Python dependencies for Travis CI
+set -ev
+touch ~/.environ
+
+# Install Python dependencies for Python specific tests
+if [[ -n "$PYTHON" ]] ; then
+  wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-4.2.12-Linux-x86_64.sh -O miniconda.sh
+  bash miniconda.sh -b -p $HOME/miniconda
+  echo "export PATH='$HOME/miniconda/bin:$PATH'" >> ~/.environ
+  source ~/.environ
+
+  hash -r
+  conda config --set always_yes yes --set changeps1 no
+  conda update -q conda
+  conda info -a
+  conda config --add channels conda-forge
+
+  conda install -q numpy=1.13.3 pandas=0.21.1 matplotlib=2.1.1 pandasql=0.7.3 ipython=5.4.1 jupyter_client=5.1.0 ipykernel=4.7.0 bokeh=0.12.10
+  pip install -q scipy==0.18.0 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
+
+  if [[ -n "$TENSORFLOW" ]] ; then
+    check_results=`conda search -c conda-forge tensorflow`
+    echo "search tensorflow = $check_results"
+
+    pip install tensorflow==${TENSORFLOW}
+  fi
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
     <plugin.checkstyle.version>2.17</plugin.checkstyle.version>
     <plugin.war.version>2.3</plugin.war.version>
 
+    <!-- submarine shaded dependency prefix-->
+    <shaded.dependency.prefix>org.apache.submarine.shaded</shaded.dependency.prefix>
+
     <!--library versions-->
     <tony.version>0.3.21</tony.version>
     <jersey.version>2.27</jersey.version>
@@ -81,9 +84,13 @@
     <commons.logging.version>1.1.3</commons.logging.version>
     <commons.cli.version>1.2</commons.cli.version>
     <snakeyaml.version>1.16</snakeyaml.version>
+    <commons-lang.version>2.6</commons-lang.version>
     <commons.lang3.version>3.4</commons.lang3.version>
+    <httpcore.version>4.4.4</httpcore.version>
+    <httpclient.version>4.5.2</httpclient.version>
     <commons.io.version>2.4</commons.io.version>
     <junit.version>4.12</junit.version>
+    <jsr305.version>3.0.0</jsr305.version>
     <mockito.version>2.23.4</mockito.version>
     <powermock.version>1.6.4</powermock.version>
     <guava.version>11.0.2</guava.version>
@@ -101,6 +108,7 @@
     <commons-io.version>2.4</commons-io.version>
     <mybatis-generator.version>1.3.7</mybatis-generator.version>
     <derby.version>10.15.1.3</derby.version>
+    <zeppelin.version>0.9.0-SNAPSHOT</zeppelin.version>
   </properties>
 
   <modules>

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -128,6 +128,13 @@
       <directory>../submarine-workbench/workbench-server/target/dependency</directory>
       <outputDirectory>/workbench/lib</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>../submarine-workbench/interpreter/python-interpreter/target</directory>
+      <outputDirectory>/workbench/interpreter/python</outputDirectory>
+      <includes>
+        <include>python-interpreter-${project.version}-shade.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
 </assembly>

--- a/submarine-workbench/interpreter/README.md
+++ b/submarine-workbench/interpreter/README.md
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+# Interpreter parent module
+
+### Compile the interpreter parent module separately
+```
+cd /submarine # submarine project root path
+mvn install package -DskipTests -pl '!submarine-all,!submarine-core,!submarine-dist,!submarine-runtime/tony-runtime,!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli,!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-server,!submarine-dist'
+```

--- a/submarine-workbench/interpreter/interpreter-engine/pom.xml
+++ b/submarine-workbench/interpreter/interpreter-engine/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.submarine</groupId>
+    <artifactId>interpreter</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>interpreter-engine</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <name>Submarine: Interpreter Engine</name>
+  <description>Submarine Interpreter Engine</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-interpreter</artifactId>
+      <version>${zeppelin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Test libraries -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies-runtime</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-dependencies-system</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>system</includeScope>
+              <excludeTransitive>true</excludeTransitive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterProcess.java
+++ b/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterProcess.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.interpreter;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Entry point for Submarine Interpreter process.
+ * Accepting thrift connections from Submarine Workbench Server.
+ */
+public abstract class InterpreterProcess {
+  public abstract void open();
+  public abstract InterpreterResult interpret(String code);
+  public abstract void close();
+  public abstract void cancel();
+  public abstract int getProgress();
+  public abstract boolean test();
+
+  private static final Logger LOG = LoggerFactory.getLogger(InterpreterProcess.class);
+
+  protected static String interpreterId;
+
+  public static void main(String[] args) throws InterruptedException, IOException {
+    String interpreterName = args[0];
+    String interpreterId = args[1];
+    String onlyTest = "";
+    if (args.length == 3) {
+      onlyTest = args[2];
+    }
+
+    InterpreterProcess interpreterProcess = loadInterpreterPlugin(interpreterName);
+
+    if (StringUtils.equals(onlyTest, "test")) {
+      boolean testResult = interpreterProcess.test();
+      LOG.info("Interpreter test result: {}", testResult);
+      System.exit(0);
+      return;
+    }
+
+    // add signal handler
+    Signal.handle(new Signal("TERM"), new SignalHandler() {
+      @Override
+      public void handle(Signal signal) {
+        // clean
+        LOG.info("handle signal:{}", signal);
+      }
+    });
+
+    System.exit(0);
+  }
+
+  // get super interpreter class name
+  private static String getSuperInterpreterClassName(String intpName) {
+    String superIntpClassName = "";
+    if (StringUtils.equals(intpName, "python")) {
+      superIntpClassName = "org.apache.submarine.interpreter.PythonInterpreter";
+    } else {
+      LOG.error("Error interpreter name : {}!", intpName);
+    }
+
+    return superIntpClassName;
+  }
+
+  public static synchronized InterpreterProcess loadInterpreterPlugin(String pluginName)
+      throws IOException {
+
+    LOG.info("Loading Plug name: {}", pluginName);
+    String pluginClassName = getSuperInterpreterClassName(pluginName);
+    LOG.info("Loading Plug Class name: {}", pluginClassName);
+
+    // load plugin from classpath directly first for these builtin Interpreter Plugin.
+    InterpreterProcess intpProcess = loadPluginFromClassPath(pluginClassName, null);
+    if (intpProcess == null) {
+      throw new IOException("Fail to load plugin: " + pluginName);
+    }
+
+    return intpProcess;
+  }
+
+  private static InterpreterProcess loadPluginFromClassPath(
+      String pluginClassName, URLClassLoader pluginClassLoader) {
+    InterpreterProcess intpProcess = null;
+    try {
+      Class<?> clazz = null;
+      if (null == pluginClassLoader) {
+        clazz = Class.forName(pluginClassName);
+      } else {
+        clazz = Class.forName(pluginClassName, true, pluginClassLoader);
+      }
+
+      Constructor<?> cons[] = clazz.getConstructors();
+      for (Constructor<?> constructor : cons) {
+        LOG.debug(constructor.getName());
+      }
+
+      Method[] methods = clazz.getDeclaredMethods();
+      //Loop through the methods and print out their names
+      for (Method method : methods) {
+        LOG.debug(method.getName());
+      }
+
+      intpProcess = (InterpreterProcess) (clazz.getConstructor().newInstance());
+      return intpProcess;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException
+        | NoSuchMethodException | InvocationTargetException e) {
+      LOG.warn("Fail to instantiate InterpreterLauncher from classpath directly:", e);
+    }
+
+    return intpProcess;
+  }
+
+  // Get the class load from the specified path
+  private static URLClassLoader getPluginClassLoader(String pluginsDir, String pluginName)
+      throws IOException {
+    File pluginFolder = new File(pluginsDir + "/" + pluginName);
+    if (!pluginFolder.exists() || pluginFolder.isFile()) {
+      LOG.warn("PluginFolder {} doesn't exist or is not a directory", pluginFolder.getAbsolutePath());
+      return null;
+    }
+    List<URL> urls = new ArrayList<>();
+    for (File file : pluginFolder.listFiles()) {
+      LOG.debug("Add file {} to classpath of plugin: {}", file.getAbsolutePath(), pluginName);
+      urls.add(file.toURI().toURL());
+    }
+    if (urls.isEmpty()) {
+      LOG.warn("Can not load plugin {}, because the plugin folder {} is empty.", pluginName, pluginFolder);
+      return null;
+    }
+    return new URLClassLoader(urls.toArray(new URL[0]));
+  }
+
+  protected Properties mergeZeplPyIntpProp(Properties newProps) {
+    Properties properties = new Properties();
+    // Max number of dataframe rows to display.
+    properties.setProperty("zeppelin.python.maxResult", "1000");
+    // whether use IPython when it is available
+    properties.setProperty("zeppelin.python.useIPython", "false");
+    properties.setProperty("zeppelin.python.gatewayserver_address", "127.0.0.1");
+
+    if (null != newProps) {
+      newProps.putAll(properties);
+      return newProps;
+    } else {
+      return properties;
+    }
+  }
+
+  protected static InterpreterContext getIntpContext() {
+    return InterpreterContext.builder()
+        .setInterpreterOut(new InterpreterOutput(null))
+        .build();
+  }
+}

--- a/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterResult.java
+++ b/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterResult.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.submarine.interpreter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Interpreter result template.
+ */
+public class InterpreterResult {
+  private static final Logger LOG = LoggerFactory.getLogger(InterpreterResult.class);
+
+  private Code code;
+  private List<InterpreterResultMessage> msg = new LinkedList<>();
+
+  public InterpreterResult(org.apache.zeppelin.interpreter.InterpreterResult result) {
+    if (result.code() == org.apache.zeppelin.interpreter.InterpreterResult.Code.SUCCESS) {
+      code = Code.SUCCESS;
+    } else if (result.code() == org.apache.zeppelin.interpreter.InterpreterResult.Code.INCOMPLETE) {
+      code = Code.INCOMPLETE;
+    } else if (result.code() == org.apache.zeppelin.interpreter.InterpreterResult.Code.ERROR) {
+      code = Code.ERROR;
+    } else if (result.code() == org.apache.zeppelin.interpreter.InterpreterResult.Code.KEEP_PREVIOUS_RESULT) {
+      code = Code.KEEP_PREVIOUS_RESULT;
+    } else {
+      LOG.error("Unknow code type : " + result.code());
+    }
+
+    for (org.apache.zeppelin.interpreter.InterpreterResultMessage message: result.message()) {
+      add(message);
+    }
+  }
+
+  public void add(org.apache.zeppelin.interpreter.InterpreterResultMessage message) {
+    Type type = Type.TEXT;
+    if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.TEXT) {
+      type = Type.TEXT;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.HTML) {
+      type = Type.HTML;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.ANGULAR) {
+      type = Type.ANGULAR;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.TABLE) {
+      type = Type.TABLE;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.IMG) {
+      type = Type.IMG;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.SVG) {
+      type = Type.SVG;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.NULL) {
+      type = Type.NULL;
+    } else if (message.getType() == org.apache.zeppelin.interpreter.InterpreterResult.Type.NETWORK) {
+      type = Type.NETWORK;
+    } else {
+      LOG.error("Unknow type : " + message.getType());
+    }
+
+    InterpreterResultMessage interpreterResultMessage = new InterpreterResultMessage(type, message.getData());
+    this.msg.add(interpreterResultMessage);
+  }
+
+  public Code code() {
+    return this.code;
+  }
+
+  public List<InterpreterResultMessage> message() {
+    return msg;
+  }
+
+  /**
+   *  Type of result after code execution.
+   */
+  public enum Code {
+    SUCCESS,
+    INCOMPLETE,
+    ERROR,
+    KEEP_PREVIOUS_RESULT
+  }
+
+  /**
+   * Type of Data.
+   */
+  public enum Type {
+    TEXT,
+    HTML,
+    ANGULAR,
+    TABLE,
+    IMG,
+    SVG,
+    NULL,
+    NETWORK
+  }
+}

--- a/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterResultMessage.java
+++ b/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/InterpreterResultMessage.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.submarine.interpreter;
+
+import java.io.Serializable;
+
+/**
+ * Interpreter result message
+ */
+public class InterpreterResultMessage implements Serializable {
+  private InterpreterResult.Type type;
+  private String data;
+
+  public InterpreterResultMessage(InterpreterResult.Type type, String data) {
+    this.type = type;
+    this.data = data;
+  }
+
+  public InterpreterResult.Type getType() {
+    return type;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public String toString() {
+    return "%" + type.name().toLowerCase() + " " + data;
+  }
+}

--- a/submarine-workbench/interpreter/pom.xml
+++ b/submarine-workbench/interpreter/pom.xml
@@ -25,21 +25,20 @@
 
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>submarine</artifactId>
+    <artifactId>submarine-workbench</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>submarine-workbench</artifactId>
+  <artifactId>interpreter</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Submarine: Workbench</name>
-  <description>Submarine Workbench</description>
+  <name>Submarine: Interpreter Parent</name>
+  <description>Submarine Interpreter Parent</description>
 
   <modules>
-    <module>interpreter</module>
-    <module>workbench-web</module>
-    <module>workbench-server</module>
+    <module>interpreter-engine</module>
+    <module>python-interpreter</module>
   </modules>
 
 </project>

--- a/submarine-workbench/interpreter/python-interpreter/README.md
+++ b/submarine-workbench/interpreter/python-interpreter/README.md
@@ -1,0 +1,39 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+# Submarine Python Interpreter
+
+## Test Submarine Python Interpreter
+
+### Execute test command
+```
+java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar python python-interpreter-id test
+```
+
+### Print test result 
+```
+ INFO [2019-10-14 10:35:11,653] ({main} SubmarinePythonInterpreter.java[test]:111) - Execution Python Interpreter, Calculation formula 1 + 1, Result = 2
+ INFO [2019-10-14 10:35:11,653] ({main} InterpreterProcess.java[main]:68) - Interpreter test result: true
+```
+
+
+## Debug Submarine Python Interpreter
+
+### Execute debug command
+
+```
+java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 python python-interpreter-id
+```
+
+Connect via remote debugging in IDEA

--- a/submarine-workbench/interpreter/python-interpreter/pom.xml
+++ b/submarine-workbench/interpreter/python-interpreter/pom.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.submarine</groupId>
+    <artifactId>interpreter</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>python-interpreter</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <name>Submarine: Interpreter Pythone</name>
+  <description>Submarine Pythone Interpreter</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.submarine</groupId>
+      <artifactId>interpreter-engine</artifactId>
+      <version>0.3.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-python</artifactId>
+      <version>${zeppelin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-interpreter</artifactId>
+      <version>${zeppelin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.atomix</groupId>
+          <artifactId>atomix</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.atomix</groupId>
+          <artifactId>atomix-raft</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.atomix</groupId>
+          <artifactId>atomix-primary-backup</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Test libraries -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${plugin.shade.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputFile>target/${project.artifactId}-${project.version}-shade.jar</outputFile>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.apache.submarine.interpreter.InterpreterProcess</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.zeppelin</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.org.apache.zeppelin</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/submarine-workbench/interpreter/python-interpreter/src/main/java/org/apache/submarine/interpreter/PythonInterpreter.java
+++ b/submarine-workbench/interpreter/python-interpreter/src/main/java/org/apache/submarine/interpreter/PythonInterpreter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.interpreter;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+public class PythonInterpreter extends InterpreterProcess {
+  private static final Logger LOG = LoggerFactory.getLogger(PythonInterpreter.class);
+
+  private org.apache.zeppelin.python.PythonInterpreter zplePythonInterpreter;
+  private InterpreterContext intpContext;
+
+  public PythonInterpreter() {
+    Properties properties = new Properties();
+    properties = mergeZeplPyIntpProp(properties);
+    zplePythonInterpreter = new org.apache.zeppelin.python.PythonInterpreter(properties);
+    zplePythonInterpreter.setInterpreterGroup(new InterpreterGroup());
+    intpContext = this.getIntpContext();
+  }
+
+  @Override
+  public void open() {
+    try {
+      zplePythonInterpreter.open();
+    } catch (InterpreterException e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public InterpreterResult interpret(String code) {
+    InterpreterResult interpreterResult = null;
+    try {
+      org.apache.zeppelin.interpreter.InterpreterResult zeplInterpreterResult
+          = zplePythonInterpreter.interpret(code, intpContext);
+      interpreterResult = new InterpreterResult(zeplInterpreterResult);
+
+      List<org.apache.zeppelin.interpreter.InterpreterResultMessage> interpreterResultMessages =
+          intpContext.out.toInterpreterResultMessage();
+
+      for (org.apache.zeppelin.interpreter.InterpreterResultMessage message : interpreterResultMessages) {
+        interpreterResult.add(message);
+      }
+    } catch (InterpreterException | IOException e) {
+      LOG.error(e.getMessage(), e);
+    }
+
+    return interpreterResult;
+  }
+
+  @Override
+  public void close() {
+    try {
+      zplePythonInterpreter.close();
+    } catch (InterpreterException e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    try {
+      zplePythonInterpreter.cancel(intpContext);
+    } catch (InterpreterException e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public int getProgress() {
+    int process = 0;
+    try {
+      process = zplePythonInterpreter.getProgress(intpContext);
+    } catch (InterpreterException e) {
+      LOG.error(e.getMessage(), e);
+    }
+
+    return process;
+  }
+
+  @Override
+  public boolean test() {
+    open();
+    String code = "1 + 1";
+    InterpreterResult result = interpret(code);
+    LOG.info("Execution Python Interpreter, Calculation formula {}, Result = {}", code, result);
+
+    if (result.code() == InterpreterResult.Code.SUCCESS) {
+      return true;
+    }
+    if (StringUtils.equals(result.message().get(0).getData(), "2\n")) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/submarine-workbench/interpreter/python-interpreter/src/main/resources/log4j.properties
+++ b/submarine-workbench/interpreter/python-interpreter/src/main/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Root logger option
+log4j.rootLogger=DEBUG, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n

--- a/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/PythonInterpreterTest.java
+++ b/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/PythonInterpreterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.interpreter;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+public class PythonInterpreterTest {
+  private static final Logger LOG = LoggerFactory.getLogger(PythonInterpreterTest.class);
+
+  private static PythonInterpreter pythonInterpreter = null;
+
+  @BeforeClass
+  public static void setUp() {
+    pythonInterpreter = new PythonInterpreter();
+    pythonInterpreter.open();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    if (null != pythonInterpreter) {
+      pythonInterpreter.close();
+    }
+  }
+
+  @Test
+  public void calcOnePlusOne() throws IOException {
+    String code = "1+1";
+    InterpreterResult result = pythonInterpreter.interpret(code);
+    LOG.info("result = {}", result);
+
+    assertEquals(result.code(), InterpreterResult.Code.SUCCESS);
+    assertEquals(result.message().get(0).getData(), "2\n"); // 1 + 1 = 2 + '\n'
+  }
+}

--- a/submarine-workbench/workbench-server/pom.xml
+++ b/submarine-workbench/workbench-server/pom.xml
@@ -22,10 +22,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>submarine</artifactId>
     <groupId>org.apache.submarine</groupId>
+    <artifactId>submarine-workbench</artifactId>
     <version>0.3.0-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.submarine</groupId>

--- a/submarine-workbench/workbench-web/pom.xml
+++ b/submarine-workbench/workbench-web/pom.xml
@@ -22,9 +22,9 @@
 
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>submarine</artifactId>
+    <artifactId>submarine-workbench</artifactId>
     <version>0.3.0-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.submarine</groupId>


### PR DESCRIPTION
### What is this PR for?
1. Submarine introduced the JAR package of Apache Zeppelin's Python interpreter through POM import. 
2. Users can enter python code in the notebook in the workbench, execute it through the python interpreter, return the running result, and implement it in the notebook.
3. Test case 1: `java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar python python-interpreter-id test`
4. Test case 2: org.apache.submarine.interpreter.SubmarinePythonInterpreterTest::calcOnePlusOne()

Design Doc: https://docs.google.com/document/d/1LJc5hRTWfIs6K5f7vMgGC_FUizeQf-qqiWICqO8SoR8/edit#


### What type of PR is it?
[Feature]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-235

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/598019228)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions?  No
* Does this needs documentation? Yes
