### PR TITLE
SUBMARINE-256. Interpreter support cluster mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
   <properties>
     <submarine.version>0.3.0-SNAPSHOT</submarine.version>
+
     <!-- language versions -->
     <java.version>1.8</java.version>
 
@@ -92,7 +93,7 @@
     <commons-lang3.version>3.4</commons-lang3.version>
     <commons.io.version>2.5</commons.io.version>
     <junit.version>4.12</junit.version>
-    <jsr305.version>3.0.0</jsr305.version>
+    <jsr305.version>1.3.9</jsr305.version>
     <mockito.version>2.23.4</mockito.version>
     <powermock.version>1.6.4</powermock.version>
     <guava.version>22.0</guava.version>

--- a/submarine-commons/commons-cluster/pom.xml
+++ b/submarine-commons/commons-cluster/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-utils</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>${submarine.version}</version>
     </dependency>
 
     <dependency>

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterClient.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterClient.java
@@ -25,23 +25,23 @@ import static org.apache.submarine.commons.cluster.meta.ClusterMetaType.INTP_PRO
 /**
  * Cluster management client class instantiated in submarine-interperter
  */
-public class ClusterManagerClient extends ClusterManager {
-  private static Logger LOG = LoggerFactory.getLogger(ClusterManagerClient.class);
+public class ClusterClient extends ClusterManager {
+  private static Logger LOG = LoggerFactory.getLogger(ClusterClient.class);
 
-  private static ClusterManagerClient instance = null;
+  private static ClusterClient instance = null;
 
   // Do not use the getInstance function in the test case,
   // which will result in an inability to update the instance according to the configuration.
-  public static ClusterManagerClient getInstance() {
-    synchronized (ClusterManagerClient.class) {
+  public static ClusterClient getInstance() {
+    synchronized (ClusterClient.class) {
       if (instance == null) {
-        instance = new ClusterManagerClient();
+        instance = new ClusterClient();
       }
-      return instance;
     }
+    return instance;
   }
 
-  private ClusterManagerClient() {
+  private ClusterClient() {
     super();
   }
 
@@ -60,9 +60,9 @@ public class ClusterManagerClient extends ClusterManager {
     return false;
   }
 
-  // In the ClusterManagerClient metaKey equal interperterGroupId
+  // In the ClusterClient metaKey equal interperterGroupId
   public void start(String metaKey) {
-    LOG.info("ClusterManagerClient::start({})", metaKey);
+    LOG.info("ClusterClient::start({})", metaKey);
     if (!sconf.workbenchIsClusterMode()) {
       return;
     }
@@ -77,7 +77,9 @@ public class ClusterManagerClient extends ClusterManager {
     if (!sconf.workbenchIsClusterMode()) {
       return;
     }
-    clusterMonitor.shutdown();
+    if (null != clusterMonitor) {
+      clusterMonitor.shutdown();
+    }
 
     super.shutdown();
   }

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterMonitor.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterMonitor.java
@@ -72,8 +72,8 @@ public class ClusterMonitor {
   // and the interperterGroupID when monitoring the interperter processes
   private String metaKey;
 
-  public ClusterMonitor(ClusterManager clusterManagerServer) {
-    this.clusterManager = clusterManagerServer;
+  public ClusterMonitor(ClusterManager clusterManager) {
+    this.clusterManager = clusterManager;
 
     SubmarineConfiguration sconf = SubmarineConfiguration.create();
     heartbeatInterval = sconf.getClusterHeartbeatInterval();

--- a/submarine-commons/commons-cluster/src/test/java/org/apache/submarine/commons/cluster/ClusterMultiNodeTest.java
+++ b/submarine-commons/commons-cluster/src/test/java/org/apache/submarine/commons/cluster/ClusterMultiNodeTest.java
@@ -38,8 +38,8 @@ import static org.junit.Assert.assertNotNull;
 public class ClusterMultiNodeTest {
   private static Logger LOG = LoggerFactory.getLogger(ClusterMultiNodeTest.class);
 
-  private static List<ClusterManagerServer> clusterServers = new ArrayList<>();
-  private static ClusterManagerClient clusterClient = null;
+  private static List<ClusterServer> clusterServers = new ArrayList<>();
+  private static ClusterClient clusterClient = null;
 
   static final String metaKey = "ClusterMultiNodeTestKey";
 
@@ -69,10 +69,10 @@ public class ClusterMultiNodeTest {
         String clusterHost = parts[0];
         int clusterPort = Integer.valueOf(parts[1]);
 
-        Class clazz = ClusterManagerServer.class;
+        Class clazz = ClusterServer.class;
         Constructor constructor = clazz.getDeclaredConstructor();
         constructor.setAccessible(true);
-        ClusterManagerServer clusterServer = (ClusterManagerServer) constructor.newInstance();
+        ClusterServer clusterServer = (ClusterServer) constructor.newInstance();
         clusterServer.initTestCluster(clusterAddrList, clusterHost, clusterPort);
 
         clusterServers.add(clusterServer);
@@ -81,17 +81,17 @@ public class ClusterMultiNodeTest {
       LOG.error(e.getMessage(), e);
     }
 
-    for (ClusterManagerServer clusterServer : clusterServers) {
+    for (ClusterServer clusterServer : clusterServers) {
       clusterServer.start();
     }
 
     // mock cluster manager client
     try {
-      Class clazz = ClusterManagerClient.class;
+      Class clazz = ClusterClient.class;
       Constructor constructor = null;
       constructor = clazz.getDeclaredConstructor();
       constructor.setAccessible(true);
-      clusterClient = (ClusterManagerClient) constructor.newInstance();
+      clusterClient = (ClusterClient) constructor.newInstance();
       clusterClient.start(metaKey);
     } catch (NoSuchMethodException | InstantiationException
         | IllegalAccessException | InvocationTargetException e) {
@@ -127,7 +127,7 @@ public class ClusterMultiNodeTest {
     if (null != clusterClient) {
       clusterClient.shutdown();
     }
-    for (ClusterManagerServer clusterServer : clusterServers) {
+    for (ClusterServer clusterServer : clusterServers) {
       clusterServer.shutdown();
     }
     LOG.info("ClusterMultiNodeTest::stopCluster <<<");
@@ -135,7 +135,7 @@ public class ClusterMultiNodeTest {
 
   static boolean clusterIsStartup() {
     boolean foundLeader = false;
-    for (ClusterManagerServer clusterServer : clusterServers) {
+    for (ClusterServer clusterServer : clusterServers) {
       if (!clusterServer.raftInitialized()) {
         LOG.warn("clusterServer not Initialized!");
         return false;

--- a/submarine-commons/pom.xml
+++ b/submarine-commons/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.apache.submarine</groupId>
     <artifactId>submarine</artifactId>
     <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/submarine-workbench/interpreter/interpreter-engine/pom.xml
+++ b/submarine-workbench/interpreter/interpreter-engine/pom.xml
@@ -37,6 +37,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.submarine</groupId>
+      <artifactId>commons-utils</artifactId>
+      <version>${submarine.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.submarine</groupId>
+      <artifactId>commons-cluster</artifactId>
+      <version>${submarine.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${zeppelin.version}</version>
@@ -135,7 +147,7 @@
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <configuration>
-          <skip>false</skip>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/Interpreter.java
+++ b/submarine-workbench/interpreter/interpreter-engine/src/main/java/org/apache/submarine/interpreter/Interpreter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.submarine.interpreter;
+
+public interface Interpreter {
+  void shutdown();
+  boolean isRunning();
+  void open();
+  InterpreterResult interpret(String code);
+  void close();
+  void cancel();
+  int getProgress();
+  boolean test();
+}

--- a/submarine-workbench/interpreter/interpreter-engine/src/main/resources/log4j.properties
+++ b/submarine-workbench/interpreter/interpreter-engine/src/main/resources/log4j.properties
@@ -16,7 +16,7 @@
 #
 
 # Root logger option
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=DEBUG, stdout
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/submarine-workbench/interpreter/python-interpreter/pom.xml
+++ b/submarine-workbench/interpreter/python-interpreter/pom.xml
@@ -82,6 +82,10 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -129,6 +133,18 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-configuration</groupId>
+          <artifactId>commons-configuration</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-math3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -151,6 +167,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/submarine-workbench/interpreter/python-interpreter/src/main/java/org/apache/submarine/interpreter/PythonInterpreter.java
+++ b/submarine-workbench/interpreter/python-interpreter/src/main/java/org/apache/submarine/interpreter/PythonInterpreter.java
@@ -108,10 +108,11 @@ public class PythonInterpreter extends InterpreterProcess {
     open();
     String code = "1 + 1";
     InterpreterResult result = interpret(code);
-    LOG.info("Execution Python Interpreter, Calculation formula {}, Result = {}", code, result);
+    LOG.info("Execution Python Interpreter, Calculation formula {}, Result = {}",
+        code, result.message().get(0).getData());
 
-    if (result.code() == InterpreterResult.Code.SUCCESS) {
-      return true;
+    if (result.code() != InterpreterResult.Code.SUCCESS) {
+      return false;
     }
     if (StringUtils.equals(result.message().get(0).getData(), "2\n")) {
       return true;

--- a/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/InterpreterClusterTest.java
+++ b/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/InterpreterClusterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.interpreter;
+
+import org.apache.submarine.commons.cluster.ClusterClient;
+import org.apache.submarine.commons.cluster.ClusterServer;
+import org.apache.submarine.commons.utils.NetUtils;
+import org.apache.submarine.commons.utils.SubmarineConfiguration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+
+import static org.apache.submarine.commons.cluster.meta.ClusterMetaType.INTP_PROCESS_META;
+import static org.apache.submarine.commons.cluster.meta.ClusterMetaType.SERVER_META;
+import static org.junit.Assert.assertEquals;
+
+public class InterpreterClusterTest {
+  private static Logger LOG = LoggerFactory.getLogger(InterpreterClusterTest.class);
+  private static SubmarineConfiguration sconf;
+
+  private static ClusterServer clusterServer = null;
+  private static ClusterClient clusterClient = null;
+
+  static String serverHost;
+  static int serverPort;
+  static final String clientMetaKey = "InterpreterProcessTest";
+
+  @BeforeClass
+  public static void startCluster() throws IOException, InterruptedException {
+    LOG.info("startCluster >>>");
+
+    sconf = SubmarineConfiguration.create();
+
+    // Set the cluster IP and port
+    serverHost = NetUtils.findAvailableHostAddress();
+    serverPort = NetUtils.findRandomAvailablePortOnAllLocalInterfaces();
+    sconf.setClusterAddress(serverHost + ":" + serverPort);
+
+    // mock cluster manager server
+    clusterServer = ClusterServer.getInstance();
+    clusterServer.start();
+
+    // mock cluster manager client
+    try {
+      Class clazz = ClusterClient.class;
+      Constructor constructor = null;
+      constructor = clazz.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      clusterClient = (ClusterClient) constructor.newInstance();
+      clusterClient.start(clientMetaKey);
+    } catch (NoSuchMethodException | InstantiationException
+        | IllegalAccessException | InvocationTargetException e) {
+      LOG.error(e.getMessage(), e);
+    }
+
+    // Waiting for cluster startup
+    int wait = 0;
+    while (wait++ < 100) {
+      if (clusterServer.isClusterLeader()
+          && clusterServer.raftInitialized()
+          && clusterClient.raftInitialized()) {
+        LOG.info("wait {}(ms) found cluster leader", wait * 3000);
+        break;
+      }
+      Thread.sleep(3000);
+    }
+    Thread.sleep(3000);
+    assertEquals(true, clusterServer.isClusterLeader()
+        && clusterServer.raftInitialized()
+        && clusterClient.raftInitialized());
+    LOG.info("startCluster <<<");
+  }
+
+  @AfterClass
+  public static void stopCluster() {
+    if (null != clusterClient) {
+      clusterClient.shutdown();
+    }
+    if (null != clusterClient) {
+      clusterServer.shutdown();
+    }
+    LOG.info("stopCluster");
+  }
+
+  @Test
+  public void testInterpreterProcess() throws IOException, InterruptedException {
+    InterpreterProcess interpreterProcess = new InterpreterProcess("python", "testInterpreterProcess", false);
+
+    startInterpreterProcess(interpreterProcess, 5000);
+
+    // Get metadata for all services
+    HashMap<String, HashMap<String, Object>> serverMeta
+        = clusterClient.getClusterMeta(SERVER_META, clusterClient.getClusterNodeName());
+    LOG.info("serverMeta.size = {}", serverMeta.size());
+    assertEquals(serverMeta.size(), 1);
+
+    // get IntpProcess Meta
+    HashMap<String, HashMap<String, Object>> intpMeta
+        = clusterClient.getClusterMeta(INTP_PROCESS_META, "testInterpreterProcess");
+    LOG.info("intpMeta.size = {}", intpMeta.size());
+    assertEquals(intpMeta.size(), 1);
+
+    HashMap<String, HashMap<String, Object>> intpMeta2
+        = clusterClient.getClusterMeta(INTP_PROCESS_META, clientMetaKey);
+    LOG.info("intpMeta2.size = {}", intpMeta2.size());
+    assertEquals(intpMeta2.size(), 1);
+
+    stopInterpreterProcess(interpreterProcess, 5000);
+  }
+
+  private void startInterpreterProcess(InterpreterProcess interpreterProcess, int timeout)
+      throws InterruptedException, IOException {
+    interpreterProcess.start();
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < timeout) {
+      if (interpreterProcess.isRunning()) {
+        break;
+      }
+      Thread.sleep(200);
+    }
+    assertEquals(true, interpreterProcess.isRunning());
+  }
+
+  private void stopInterpreterProcess(InterpreterProcess interpreterProcess, int timeout)
+      throws InterruptedException {
+    interpreterProcess.shutdown();
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < timeout) {
+      if (!interpreterProcess.isRunning()) {
+        break;
+      }
+      Thread.sleep(200);
+    }
+    assertEquals(false, interpreterProcess.isRunning());
+  }
+}

--- a/submarine-workbench/workbench-server/src/main/java/org/apache/submarine/server/WorkbenchServer.java
+++ b/submarine-workbench/workbench-server/src/main/java/org/apache/submarine/server/WorkbenchServer.java
@@ -20,7 +20,7 @@ package org.apache.submarine.server;
 
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.submarine.websocket.NotebookServer;
-import org.apache.submarine.commons.cluster.ClusterManagerServer;
+import org.apache.submarine.commons.cluster.ClusterServer;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -92,8 +92,8 @@ public class WorkbenchServer extends ResourceConfig {
     // Notebook server
     setupNotebookServer(webApp, conf, sharedServiceLocator);
 
-    // Cluster Manager Server
-    setupClusterManagerServer();
+    // Cluster Server
+    setupClusterServer();
 
     startServer();
   }
@@ -222,10 +222,10 @@ public class WorkbenchServer extends ResourceConfig {
     webapp.addServlet(servletHolder, "/ws/*");
   }
 
-  private static void setupClusterManagerServer() {
+  private static void setupClusterServer() {
     if (conf.workbenchIsClusterMode()) {
-      ClusterManagerServer clusterManagerServer = ClusterManagerServer.getInstance();
-      clusterManagerServer.start();
+      ClusterServer clusterServer = ClusterServer.getInstance();
+      clusterServer.start();
     }
   }
 

--- a/submarine-workbench/workbench-server/src/test/java/org/apache/submarine/server/WorkbenchClusterServerTest.java
+++ b/submarine-workbench/workbench-server/src/test/java/org/apache/submarine/server/WorkbenchClusterServerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.submarine.server;
 
-import org.apache.submarine.commons.cluster.ClusterManagerClient;
+import org.apache.submarine.commons.cluster.ClusterClient;
 import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
 import org.apache.submarine.commons.utils.NetUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class WorkbenchClusterServerTest {
   private static final Logger LOG = LoggerFactory.getLogger(WorkbenchClusterServerTest.class);
 
-  private static ClusterManagerClient clusterClient = null;
+  private static ClusterClient clusterClient = null;
 
   @BeforeClass
   public static void start() throws Exception {
@@ -55,11 +55,11 @@ public class WorkbenchClusterServerTest {
     AbstractWorkbenchServerTest.startUp(WorkbenchClusterServerTest.class.getSimpleName());
 
     // Mock Cluster client
-    Class clazz = ClusterManagerClient.class;
+    Class clazz = ClusterClient.class;
     Constructor constructor = null;
     constructor = clazz.getDeclaredConstructor();
     constructor.setAccessible(true);
-    clusterClient = (ClusterManagerClient) constructor.newInstance();
+    clusterClient = (ClusterClient) constructor.newInstance();
     clusterClient.start("TestWorkbenchClusterServer");
 
     // Waiting for cluster startup


### PR DESCRIPTION
### What is this PR for?
After the interpreter integrates the cluster module,
When the interpreter is started, the `interpreter ID`, `IP` and `port` of the interpreter are registered in the metadata of the cluster, so that the interpreter can be found in the entire cluster and used by the notebook and workbench server.


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-256

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/601138608)
* InterpreterClusterTest.java

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
