### PR TITLE
SUBMARINE-260. Remove submarine.version properties define in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
   </licenses>
 
   <properties>
-    <submarine.version>0.3.0-SNAPSHOT</submarine.version>
-
     <!-- language versions -->
     <java.version>1.8</java.version>
 

--- a/submarine-client/pom.xml
+++ b/submarine-client/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-runtime</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-runtime</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/submarine-commons/commons-cluster/pom.xml
+++ b/submarine-commons/commons-cluster/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-utils</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/submarine-workbench/interpreter/interpreter-engine/pom.xml
+++ b/submarine-workbench/interpreter/interpreter-engine/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-utils</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-cluster</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/submarine-workbench/interpreter/python-interpreter/pom.xml
+++ b/submarine-workbench/interpreter/python-interpreter/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>interpreter-engine</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zeppelin</groupId>

--- a/submarine-workbench/workbench-server/pom.xml
+++ b/submarine-workbench/workbench-server/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.submarine</groupId>
       <artifactId>commons-cluster</artifactId>
-      <version>${submarine.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
The submarine.version property is now defined in the pom.xml file. In fact, this property is duplicated with project.version.
So need to delete.


### What type of PR is it?
[Improvement]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-260

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/602666779)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
