### PR TITLE
SUBMARINE-262. Two different version of commons-io in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <httpclient.version>4.5.2</httpclient.version>
     <commons-lang.version>2.5</commons-lang.version>
     <commons-lang3.version>3.4</commons-lang3.version>
-    <commons.io.version>2.5</commons.io.version>
+    <commons-io.version>2.5</commons-io.version>
     <junit.version>4.12</junit.version>
     <jsr305.version>1.3.9</jsr305.version>
     <mockito.version>2.23.4</mockito.version>
@@ -106,7 +106,6 @@
     <zip4j.version>1.3.2</zip4j.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <nimbus-jose-jwt.version>4.41.1</nimbus-jose-jwt.version>
-    <commons-io.version>2.4</commons-io.version>
     <mybatis-generator.version>1.3.7</mybatis-generator.version>
     <derby.version>10.15.1.3</derby.version>
     <zeppelin.version>0.9.0-SNAPSHOT</zeppelin.version>

--- a/submarine-server/server-submitter/submitter-yarnservice/pom.xml
+++ b/submarine-server/server-submitter/submitter-yarnservice/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons.io.version}</version>
+      <version>${commons-io.version}</version>
     </dependency>
 
     <!-- Dependencies for Hadoop commons -->


### PR DESCRIPTION
 ### What is this PR for?
resolve the problem of the duplicated version of `commons.io`

 ### What type of PR is it?
[Bug Fix]

 ### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-262

 ### How should this be tested?
* https://travis-ci.org/hhhizzz/hadoop-submarine/builds/603829334

 ### Questions:
* Does the licenses files need an update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
